### PR TITLE
Update colors.xml: change default background color to something less funky

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -32,7 +32,7 @@
 
     <color name="clock_gray">#B3FFFFFF</color>
 
-    <color name="default_background">#1A237E</color>
+    <color name="default_background">#202124</color>
 
     <!-- shadowColor for widget text -->
     <color name="widget_shadow_color">#67000000</color>


### PR DESCRIPTION
default aosp clock background looks bad ,,, so why not change it from old look background to dark mode like background same as google clock 
![unnamed](https://user-images.githubusercontent.com/61591769/78343514-78274e80-758a-11ea-9aa6-f8f7a99754e5.png)
