### PR TITLE
don't allow other apps to snooze or dismiss alarms

### DIFF
--- a/src/com/android/deskclock/alarms/AlarmActivity.java
+++ b/src/com/android/deskclock/alarms/AlarmActivity.java
@@ -95,12 +95,6 @@ public class AlarmActivity extends BaseActivity
 
             if (!mAlarmHandled) {
                 switch (action) {
-                    case AlarmService.ALARM_SNOOZE_ACTION:
-                        snooze();
-                        break;
-                    case AlarmService.ALARM_DISMISS_ACTION:
-                        dismiss();
-                        break;
                     case AlarmService.ALARM_DONE_ACTION:
                         finish();
                         break;
@@ -265,9 +259,7 @@ public class AlarmActivity extends BaseActivity
         if (!mReceiverRegistered) {
             // Register to get the alarm done/snooze/dismiss intent.
             final IntentFilter filter = new IntentFilter(AlarmService.ALARM_DONE_ACTION);
-            filter.addAction(AlarmService.ALARM_SNOOZE_ACTION);
-            filter.addAction(AlarmService.ALARM_DISMISS_ACTION);
-            registerReceiver(mReceiver, filter);
+            registerReceiver(mReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
             mReceiverRegistered = true;
         }
 


### PR DESCRIPTION
Also protect ALARM_DONE_ACTION (it closes the AlarmActivity) by marking its receiver as
Context.RECEIVER_NOT_EXPORTED.